### PR TITLE
Add .claude/settings.json for cekernel permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Edit",
+      "Write",
+      "Read"
+    ],
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(rm -rf /)",
+      "Bash(rm -rf /*)",
+      "Bash(shutdown *)",
+      "Bash(reboot *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- cekernel サブエージェント (Orchestrator/Worker) が Bash 実行権限不足で起動できない問題を解決
- `.claude/settings.json` にプロジェクトレベルの権限設定を追加
- Bash/Edit/Write/Read を許可、危険コマンド (sudo, rm -rf /, shutdown, reboot) は明示的に拒否

Closes #2

## Test plan
- [ ] cekernel Orchestrator がサブエージェントとして Bash を実行できることを確認
- [ ] `/cekernel:orchestrate` で Issue を委任し、Worker が正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)