### PR TITLE
Setup: .gitignore に cekernel 用エントリを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *.db-shm
 *.db-wal
 node_modules/
+
+# cekernel
+.worktrees/
+.cekernel*


### PR DESCRIPTION
closes #7

## Summary
- `.gitignore` に `# cekernel` ブロックを追加
- `.worktrees/` — git worktree ディレクトリを除外
- `.cekernel*` — `.cekernel-env`、`.cekernel-checkpoint`、`.cekernel-tasks` 等を除外

## Test Plan
- [x] `.gitignore` の差分を目視確認