### PR TITLE
Add TDD development process and update documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,18 +16,39 @@ make up      # devcontainer 起動
 make test    # コンテナ内で cargo test
 make build   # コンテナ内で cargo build
 make run     # コンテナ内で cargo run (http://0.0.0.0:3000)
-make exec CMD="cargo clippy"  # 任意コマンド実行
+make fmt     # コード整形 (cargo fmt)
+make lint    # clippy チェック
+make check   # fmt → lint → test 一括実行
+make ci      # CI 再現 (fmt --check → clippy → test → build --release)
+make down    # devcontainer 停止
 ```
 
 git worktreeで複数コンテナを同時起動可能。コンテナ名は `cekernel-<フォルダ名>` で一意になる。
+
+## Development Process (TDD)
+
+1. **RED**: テストを書く → `make test` で失敗を確認
+2. **GREEN**: 最小限の実装 → `make test` でパス
+3. **REFACTOR**: リファクタ → `make check` で全チェック（fmt + lint + test）
+4. **PR前**: `make ci` でCI再現確認
+
+### Worker ライフサイクル
+
+cekernel Worker は以下の順序で devcontainer を利用する:
+
+```
+make up → TDD サイクル (RED → GREEN → REFACTOR) → make ci → PR作成 → make down
+```
 
 ## Architecture
 
 - **Framework**: Axum 0.7（軽量Web）+ SQLite（sqlx async）
 - **エントリポイント**: `src/main.rs` — DB接続・サーバー起動（`PORT` 環境変数でポート指定可）
-- **ビジネスロジック**: `src/lib.rs` — ルーター、ハンドラ、モデル、テストすべてを含む
+- **ルーター・DB初期化**: `src/lib.rs` — `app()`, `setup_db()`, re-exports
+- **モデル**: `src/models.rs` — `Todo`, `CreateTodo`, `UpdateTodo`
+- **ハンドラ**: `src/handlers.rs` — CRUD ハンドラ
 - **DB**: SQLite ファイル (`todos.db`)。コンテナ内でのみ存在し、gitignore済み。マイグレーションは `setup_db()` でアプリ起動時に実行
-- **テスト**: `src/lib.rs` 内の `#[cfg(test)]` モジュール。`sqlite::memory:` を使うためDBファイル不要
+- **テスト**: `tests/api.rs` — インテグレーションテスト。`sqlite::memory:` を使うためDBファイル不要
 
 ## API Endpoints
 
@@ -40,6 +61,6 @@ git worktreeで複数コンテナを同時起動可能。コンテナ名は `cek
 
 ## Conventions
 
-- TDDアプローチ: テストを `src/lib.rs` の `tests` モジュールに追加してから実装
+- TDDアプローチ: テストを `tests/api.rs` に追加してから実装
 - 状態管理は `Arc<SqlitePool>` を Axum の `State` extractor で共有
 - テストは `tower::ServiceExt::oneshot` でルーターに直接リクエストを送る（HTTPサーバー不要）

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DEVCONTAINER = pnpm exec devcontainer
 WORKSPACE = --workspace-folder .
 DEV = $(DEVCONTAINER) exec $(WORKSPACE) make -f dev.mk
 
-.PHONY: help setup up down rebuild test build run stop clean port shell exec
+.PHONY: help setup up down rebuild fmt lint check ci test build run stop clean port shell exec
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
@@ -24,6 +24,18 @@ down: ## Stop and remove devcontainer
 
 rebuild: down ## Rebuild and start devcontainer from scratch
 	$(DEVCONTAINER) up $(WORKSPACE) --build-no-cache
+
+fmt: up ## Format code (delegates to dev.mk)
+	$(DEV) fmt
+
+lint: up ## Run clippy (delegates to dev.mk)
+	$(DEV) lint
+
+check: up ## Full check: format → lint → test (delegates to dev.mk)
+	$(DEV) check
+
+ci: up ## Reproduce CI locally (delegates to dev.mk)
+	$(DEV) ci
 
 test: up ## Run tests (delegates to dev.mk)
 	$(DEV) test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
-# text-cekernel
-test repository for cekernel
+# test-cekernel
+
+[cekernel](https://github.com/clonable-eden/plugins) の実証テスト用リポジトリ。Rust + Axum によるシンプルな TODO リスト REST API。
+
+## Setup
+
+ホストに Node.js 24 LTS + pnpm が必要（devcontainer CLI 用）。Rust はコンテナ内に閉じ込める。
+
+```bash
+make setup   # pnpm install (devcontainer CLI)
+make up      # devcontainer 起動
+make run     # サーバー起動 (http://localhost:3000)
+```
+
+## Make Targets
+
+| Target | Description |
+|--------|-------------|
+| `make setup` | ホスト依存関係インストール |
+| `make up` | devcontainer 起動 |
+| `make down` | devcontainer 停止 |
+| `make test` | テスト実行 |
+| `make build` | ビルド |
+| `make run` | サーバー起動 |
+| `make fmt` | コード整形 (`cargo fmt`) |
+| `make lint` | lint (`cargo clippy`) |
+| `make check` | fmt → lint → test 一括実行 |
+| `make ci` | CI 再現 (fmt --check → clippy → test → build --release) |
+
+## API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /todos | 一覧取得 |
+| POST | /todos | 作成 (`{"title": "..."}`) |
+| PATCH | /todos/:id | 更新 (`{"title": "...", "completed": true}`) |
+| DELETE | /todos/:id | 削除 |
+
+## Development
+
+TDD アプローチで開発する。
+
+1. **RED**: テストを書く → `make test` で失敗を確認
+2. **GREEN**: 最小限の実装 → `make test` でパス
+3. **REFACTOR**: リファクタ → `make check` で全チェック
+4. **PR前**: `make ci` で CI 再現確認
+
+## Project Structure
+
+```
+src/
+  main.rs        — エントリポイント（DB接続・サーバー起動）
+  lib.rs         — ルーター・DB初期化・re-exports
+  models.rs      — データモデル (Todo, CreateTodo, UpdateTodo)
+  handlers.rs    — CRUD ハンドラ
+tests/
+  api.rs         — インテグレーションテスト
+```

--- a/dev.mk
+++ b/dev.mk
@@ -1,11 +1,25 @@
 PORT ?= 3000
 
-.PHONY: help test build run stop clean
+.PHONY: help fmt lint check ci test build run stop clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
 
-test: build ## Run tests
+fmt: ## Format code
+	cargo fmt
+
+lint: ## Run clippy
+	cargo clippy -- -D warnings
+
+check: fmt lint test ## Full check (format → lint → test)
+
+ci: ## Reproduce CI locally (no auto-fix)
+	cargo fmt --check
+	cargo clippy -- -D warnings
+	cargo test
+	cargo build --release
+
+test: ## Run tests
 	cargo test
 
 build: ## Build the project


### PR DESCRIPTION
## Summary
- `dev.mk` に `fmt`, `lint`, `check`, `ci` ターゲットを追加
- `Makefile` に devcontainer 経由の委譲ターゲットを追加
- `CLAUDE.md` を現在のアーキテクチャに更新、TDD プロセスと Worker ライフサイクルを定義
- `README.md` を全面更新（セットアップ、ターゲット一覧、API、プロジェクト構成）

Closes #9

## Test plan
- [ ] `make help` で新ターゲット (fmt, lint, check, ci) が表示されること
- [ ] CI がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)