### PR TITLE
Update CI with changed-files filter and gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      src: ${{ steps.filter.outputs.src_any_modified }}
+      src: ${{ steps.filter.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4
       - uses: tj-actions/changed-files@v47


### PR DESCRIPTION
## Summary
- `tj-actions/changed-files` でソースファイルの変更を検出
- docs のみの PR では check ジョブをスキップ
- `gate` ジョブを追加（Ruleset のステータスチェック対象として使用）

Part of #12

## Test plan
- [x] ソース変更を含む PR で check → gate が両方パスすること
- [x] CI ワークフロー変更自体でも check がトリガーされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)