### PR TITLE
Fix: README.md の cekernel リンクを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # test-cekernel
 
-[cekernel](https://github.com/clonable-eden/plugins) の実証テスト用リポジトリ。Rust + Axum によるシンプルな TODO リスト REST API。
+[cekernel](https://github.com/clonable-eden/cekernel) の実証テスト用リポジトリ。Rust + Axum によるシンプルな TODO リスト REST API。
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- cekernel へのリンクを `clonable-eden/plugins` → `clonable-eden/cekernel` に修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)