### PR TITLE
Setup: rust-toolchain.toml を追加

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
closes #16

## Summary
- `rust-toolchain.toml` を追加し、Rust ツールチェインを `stable` にピン留め
- `rustfmt` と `clippy` コンポーネントを指定
- ローカル・CI・devcontainer 間のバージョンずれを防止

## Test Plan
- [x] `make ci` でCIを再現確認（fmt check / clippy / test 8 passed / build --release）