### PR TITLE
Configure Renovate: pin GHA digests and group dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
+      "matchUpdateTypes": ["patch", "minor", "pin"],
       "automerge": true
     },
     {


### PR DESCRIPTION
## Summary
- GHA actions を SHA digest にピン留め (`helpers:pinGitHubActionDigests`)
- Rust 依存を1 PR にグルーピング
- GHA actions 更新を1 PR にグルーピング

Closes #17

## Test plan
- [ ] Renovate が次回スキャン時に GHA の digest pin PR を作成すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)