### PR TITLE
Add minimumReleaseAge to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "minor", "pin"],


### PR DESCRIPTION
## Summary
- `minimumReleaseAge: "7 days"` を追加
- リリース直後の不安定なバージョンを避ける

🤖 Generated with [Claude Code](https://claude.com/claude-code)