### PR TITLE
Fix: add pinDigest to Renovate automerge types

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "minor", "pin"],
+      "matchUpdateTypes": ["patch", "minor", "pinDigest"],
       "automerge": true
     },
     {


### PR DESCRIPTION
## Summary
- `pinDigest` を automerge 対象に追加（GHA の SHA digest ピン留めを自動マージ）
- `pin` を削除（Cargo.lock で管理済み、GHA は pinDigest のため不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)