### PR TITLE
Fix: LICENSE-APACHE の著作権表示を更新

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Ryosuke Kawamura
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- LICENSE-APACHE の著作権表示がテンプレートのデフォルト値 `Copyright [yyyy] [name of copyright owner]` のままだったため、`Copyright 2026 Ryosuke Kawamura` に修正

## Test plan
- [x] LICENSE-APACHE の190行目が正しく更新されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)