### PR TITLE
Update: Rust edition を 2021 → 2024 に更新

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-cekernel"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 axum = "0.8"

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,7 +1,7 @@
 use axum::{
+    Json,
     extract::{Path, State},
     http::StatusCode,
-    Json,
 };
 use sqlx::SqlitePool;
 use std::sync::Arc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub mod models;
 pub use handlers::AppState;
 pub use models::{CreateTodo, Todo, UpdateTodo};
 
-use axum::{routing::get, Router};
+use axum::{Router, routing::get};
 use sqlx::SqlitePool;
 use std::sync::Arc;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::SqlitePool;
+use sqlx::sqlite::SqliteConnectOptions;
 use std::str::FromStr;
 use test_cekernel::{app, setup_db};
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,11 +1,11 @@
+use axum::Router;
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
-use axum::Router;
 use http_body_util::BodyExt;
 use sqlx::SqlitePool;
 use tower::ServiceExt;
 
-use test_cekernel::{app, setup_db, Todo};
+use test_cekernel::{Todo, app, setup_db};
 
 async fn test_app() -> Router {
     let pool = SqlitePool::connect("sqlite::memory:")


### PR DESCRIPTION
closes #33

## Summary
- `Cargo.toml` の `edition = "2021"` → `edition = "2024"` に変更
- Rust 2024 edition の `rustfmt` ルールに従い import 順序を整形（`cargo fmt` 適用）
- `cargo fix --edition` 実行: コードロジックへの変更は不要（既に 2024 対応済み）

## Test Plan
- [x] `make ci` 完了: fmt --check / clippy / test (8 passed) / build --release すべて通過