### PR TITLE
feat: renovate.json に platformAutomerge: true を追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "platformAutomerge": true,
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"


### PR DESCRIPTION
closes #35

## Summary
- `renovate.json` に `platformAutomerge: true` を追加
- GitHub ネイティブの auto-merge 機能を利用し、CI パス後に automerge 対象 PR が自動マージされるようにする

## Test Plan
- [x] `make ci` でローカル CI 再現確認（fmt, clippy, test, build --release 全パス）
- [x] renovate.json の JSON 構文が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)