### PR TITLE
Improvement: GHA CI で dev.mk ターゲットを利用する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,17 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: fmt
-        run: cargo fmt --check
+      - name: fmt-check
+        run: make -f dev.mk fmt-check
 
-      - name: clippy
-        run: cargo clippy -- -D warnings
+      - name: lint
+        run: make -f dev.mk lint
 
       - name: test
-        run: cargo test
+        run: make -f dev.mk test
 
       - name: build
-        run: cargo build --release
+        run: make -f dev.mk build-release
 
   gate:
     needs: check

--- a/dev.mk
+++ b/dev.mk
@@ -1,6 +1,6 @@
 PORT ?= 3000
 
-.PHONY: help fmt lint check ci test build run stop clean
+.PHONY: help fmt fmt-check lint check ci test build build-release run stop clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
@@ -8,22 +8,24 @@ help: ## Show this help
 fmt: ## Format code
 	cargo fmt
 
+fmt-check: ## Check formatting (no auto-fix)
+	cargo fmt --check
+
 lint: ## Run clippy
 	cargo clippy -- -D warnings
 
 check: fmt lint test ## Full check (format → lint → test)
 
-ci: ## Reproduce CI locally (no auto-fix)
-	cargo fmt --check
-	cargo clippy -- -D warnings
-	cargo test
-	cargo build --release
+ci: fmt-check lint test build-release ## Reproduce CI locally (no auto-fix)
 
 test: ## Run tests
 	cargo test
 
 build: ## Build the project
 	cargo build
+
+build-release: ## Build in release mode
+	cargo build --release
 
 run: ## Start server in background
 	@cargo run &


### PR DESCRIPTION
## Summary

- GHA CI ワークフローの `cargo` コマンド直書きを `make -f dev.mk` 呼び出しに置換
- `dev.mk` に `fmt-check`, `build-release` ターゲットを追加し、`ci` ターゲットを依存構成に変更
- ローカル (`make ci`) と CI の実行コマンドを一元化

## Changes

- `dev.mk` — `fmt-check`, `build-release` 追加、`ci` ターゲット更新
- `.github/workflows/ci.yml` — 各ステップを `make -f dev.mk` 呼び出しに置換

## Test plan

- [ ] `make -f dev.mk fmt-check` がフォーマット違反を検出すること
- [ ] `make -f dev.mk build-release` がリリースビルドを実行すること
- [ ] `make -f dev.mk ci` が全ステップを順番に実行すること
- [ ] GHA CI が正常に通ること

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)