### PR TITLE
docs: MakefileターゲットとREADME/CLAUDE.mdの記述を整合させる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,16 +11,23 @@ cekernelの実証テスト用リポジトリ。Rust + Axum によるシンプル
 すべての開発はdevcontainer内で行う。ホストには Node.js 24 LTS + pnpm が必要（devcontainer CLI 用）。Rustはコンテナ内に閉じ込める。
 
 ```bash
-make setup   # ホスト側: pnpm install (devcontainer CLI)
-make up      # devcontainer 起動
-make test    # コンテナ内で cargo test
-make build   # コンテナ内で cargo build
-make run     # コンテナ内で cargo run (http://0.0.0.0:3000)
-make fmt     # コード整形 (cargo fmt)
-make lint    # clippy チェック
-make check   # fmt → lint → test 一括実行
-make ci      # CI 再現 (fmt --check → clippy → test → build --release)
-make down    # devcontainer 停止
+make help      # ターゲット一覧を表示
+make setup     # ホスト側: pnpm install (devcontainer CLI)
+make up        # devcontainer 起動（起動済みならスキップ）
+make down      # devcontainer 停止・削除
+make rebuild   # devcontainer を再ビルドして起動
+make fmt       # コード整形 (cargo fmt)
+make lint      # clippy チェック
+make check     # fmt → lint → test 一括実行
+make ci        # CI 再現 (fmt --check → clippy → test → build --release)
+make test      # コンテナ内で cargo test
+make build     # コンテナ内で cargo build
+make run       # サーバーをバックグラウンドで起動
+make stop      # 実行中のサーバーを停止
+make clean     # ビルド成果物を削除
+make port      # サーバーのホスト側ポートを表示
+make shell     # devcontainer 内でシェルを開く
+make exec      # 任意コマンド実行 (例: make exec CMD="cargo clippy")
 ```
 
 git worktreeで複数コンテナを同時起動可能。コンテナ名は `cekernel-<フォルダ名>` で一意になる。

--- a/README.md
+++ b/README.md
@@ -14,18 +14,7 @@ make run     # サーバー起動 (http://localhost:3000)
 
 ## Make Targets
 
-| Target | Description |
-|--------|-------------|
-| `make setup` | ホスト依存関係インストール |
-| `make up` | devcontainer 起動 |
-| `make down` | devcontainer 停止 |
-| `make test` | テスト実行 |
-| `make build` | ビルド |
-| `make run` | サーバー起動 |
-| `make fmt` | コード整形 (`cargo fmt`) |
-| `make lint` | lint (`cargo clippy`) |
-| `make check` | fmt → lint → test 一括実行 |
-| `make ci` | CI 再現 (fmt --check → clippy → test → build --release) |
+全ターゲットの一覧は `make help` で確認できる。
 
 ## API
 


### PR DESCRIPTION
closes #38

## Summary
- README.md の Make Targets テーブルを削除し、`make help` への誘導に置き換え
- CLAUDE.md に Makefile の全17ターゲットを明示的に列挙（help, rebuild, stop, clean, port, shell, exec を追加）

## Test Plan
- [ ] `make help` で全ターゲットが表示されることを確認
- [ ] README.md / CLAUDE.md の記述が Makefile と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)