### PR TITLE
TDDの各ステップでのコミットとサフィックス規約を必須化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,11 @@ git worktreeで複数コンテナを同時起動可能。コンテナ名は `cek
 
 ## Development Process (TDD)
 
-1. **RED**: テストを書く → `make test` で失敗を確認
-2. **GREEN**: 最小限の実装 → `make test` でパス
-3. **REFACTOR**: リファクタ → `make check` で全チェック（fmt + lint + test）
+各ステップで必ずコミットすること。コミットメッセージ末尾に TDD ステップを示すサフィックスを付ける。
+
+1. **RED**: テストを書く → `make test` で失敗を確認 → コミット (`test: <説明> (RED)`)
+2. **GREEN**: 最小限の実装 → `make test` でパス → コミット (`feat: <説明> (GREEN)` または `fix: <説明> (GREEN)`)
+3. **REFACTOR**: リファクタ → `make check` で全チェック（fmt + lint + test） → コミット (`refactor: <説明> (REFACTOR)`)（変更がある場合）
 4. **PR前**: `make ci` でCI再現確認
 
 ### Worker ライフサイクル


### PR DESCRIPTION
closes #44

## Summary
- CLAUDE.mdの `Development Process (TDD)` セクションを更新
- RED/GREEN/REFACTORの各ステップでコミットを必須とする指示を追加
- コミットメッセージ末尾にTDDステップを示すサフィックス (`(RED)`, `(GREEN)`, `(REFACTOR)`) を付ける規約を明記

## Test Plan
- [x] `make ci` でCI再現確認（fmt, clippy, test 13/13, build --release すべてパス）
- [x] CLAUDE.mdの変更内容がissue #44の要件と一致することを確認