### PR TITLE
fix(ci): changed-files フィルタに templates/, static/, rust-toolchain.toml を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
             dev.mk
             Makefile
             .github/workflows/**
+            templates/**
+            static/**
+            rust-toolchain.toml
 
   check:
     needs: changes


### PR DESCRIPTION
closes #101

## Summary
- `ci.yml` の `changed-files` フィルタに `templates/**`, `static/**`, `rust-toolchain.toml` を追加
- これらのファイルのみ変更したPRでCIがスキップされる問題を修正

## Test Plan
- [ ] `templates/` のみ変更したPRでCIが実行されることを確認
- [ ] `static/` のみ変更したPRでCIが実行されることを確認
- [ ] `rust-toolchain.toml` のみ変更したPRでCIが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)