### PR TITLE
CI: cargo audit によるセキュリティスキャン追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: build
         run: make -f dev.mk build-release
 
+      - name: security audit
+        run: cargo install cargo-audit --locked && cargo audit
+
   gate:
     needs: check
     if: always()


### PR DESCRIPTION
closes #102

## Summary
- CI の `check` ジョブに `cargo audit` ステップを追加
- RustSec Advisory DB に基づく既知脆弱性を PR 単位で検出可能に
- サードパーティ Action を使わず `cargo install cargo-audit --locked && cargo audit` で実行

## Test Plan
- [ ] CI が正常に通ること（`cargo audit` ステップ含む）