### PR TITLE
ci: replace cargo-audit with rustsec/audit-check action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
         run: make -f dev.mk build-release
 
       - name: security audit
-        run: cargo install cargo-audit --locked && cargo audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   gate:
     needs: check


### PR DESCRIPTION
closes #109

## Summary
- `cargo install cargo-audit --locked && cargo audit` を `rustsec/audit-check@v2.0.0` (digest pin) に置換
- pre-built バイナリにより security audit ステップを約2分→5-10秒に短縮
- Renovate が digest pin を自動管理

## Test Plan
- [ ] CI の `security audit` ステップが `rustsec/audit-check` action で実行される
- [ ] CI 全体が通過する

🤖 Generated with [Claude Code](https://claude.com/claude-code)