### PR TITLE
feat: add GET /health endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ make up → TDD サイクル (RED → GREEN → REFACTOR) → make ci → PR作�
 
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | /health | ヘルスチェック (`{"status":"ok"}` or `503 {"status":"unhealthy","error":"..."}`) |
 | GET | /todos | 一覧取得 |
 | POST | /todos | 作成 (`{"title": "..."}`) |
 | PATCH | /todos/:id | 更新 (`{"title": "...", "completed": true}`) |

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -12,6 +12,21 @@ use crate::models::{CreateTodo, CreateTodoForm, Todo, UpdateTodo};
 
 pub type AppState = Arc<SqlitePool>;
 
+pub async fn health_check(
+    State(pool): State<AppState>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    match sqlx::query("SELECT 1").execute(pool.as_ref()).await {
+        Ok(_) => Ok(Json(serde_json::json!({"status": "ok"}))),
+        Err(e) => {
+            tracing::error!(error = %e, "Health check failed");
+            Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"status": "unhealthy", "error": e.to_string()})),
+            ))
+        }
+    }
+}
+
 pub async fn list_todos(State(pool): State<AppState>) -> Result<Json<Vec<Todo>>, StatusCode> {
     let todos = fetch_todos(&pool).await?;
     Ok(Json(todos))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ use tower_http::services::ServeDir;
 use tower_http::trace::TraceLayer;
 
 use handlers::{
-    create_todo, create_todo_html, delete_todo, delete_todo_html, index_page, list_todos,
-    toggle_todo_html, update_todo,
+    create_todo, create_todo_html, delete_todo, delete_todo_html, health_check, index_page,
+    list_todos, toggle_todo_html, update_todo,
 };
 
 pub async fn setup_db(pool: &SqlitePool) {
@@ -35,6 +35,7 @@ pub fn app(pool: SqlitePool) -> Router {
     let state: AppState = Arc::new(pool);
     Router::new()
         .route("/", get(index_page).post(create_todo_html))
+        .route("/health", get(health_check))
         .route("/todos", get(list_todos).post(create_todo))
         .route(
             "/todos/{id}",

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -515,6 +515,44 @@ async fn test_delete_todo_html() {
     );
 }
 
+// ---- Health Check Tests ----
+
+#[tokio::test]
+async fn test_health_ok() {
+    let app = test_app().await;
+    let res = app
+        .oneshot(json_request(Method::GET, "/health", None))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: serde_json::Value = body_json(res).await;
+    assert_eq!(body["status"], "ok");
+}
+
+#[tokio::test]
+async fn test_health_unhealthy() {
+    let pool = SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("Failed to connect");
+    setup_db(&pool).await;
+    let router = app(pool.clone());
+
+    // Close the pool to simulate DB failure
+    pool.close().await;
+
+    let res = router
+        .oneshot(json_request(Method::GET, "/health", None))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body: serde_json::Value = body_json(res).await;
+    assert_eq!(body["status"], "unhealthy");
+    assert!(
+        body["error"].as_str().is_some(),
+        "error field should be present"
+    );
+}
+
 // ---- Tracing Tests ----
 
 /// A tracing layer that records event messages to a shared buffer.


### PR DESCRIPTION
closes #111

## Summary
- Add `GET /health` endpoint that checks DB connectivity via `SELECT 1`
- Returns `200 {"status":"ok"}` on success, `503 {"status":"unhealthy","error":"..."}` on failure
- Add integration tests for both healthy and unhealthy states
- Update CLAUDE.md API Endpoints table

## Test Plan
- [x] `test_health_ok` — verifies 200 response with `{"status":"ok"}`
- [x] `test_health_unhealthy` — verifies 503 response with error details when DB is closed
- [x] All 21 tests pass, `make ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)