### PR TITLE
feat: エラーレスポンスの構造化 + tracing 連携

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,48 @@
+use axum::{
+    extract::rejection::JsonRejection,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+
+/// JSON error response body: `{ "error": "message" }`.
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+/// Application-level error type that renders as a JSON error response.
+#[derive(Debug)]
+pub enum AppError {
+    /// 404 Not Found — resource does not exist.
+    NotFound(String),
+    /// 400 Bad Request — invalid input from client.
+    BadRequest(String),
+    /// 500 Internal Server Error — unexpected server-side failure.
+    /// The inner string is logged via tracing but NOT exposed to the client.
+    Internal(String),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
+            AppError::Internal(detail) => {
+                tracing::error!(error = %detail, "Internal server error");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal server error".to_string(),
+                )
+            }
+        };
+        (status, Json(ErrorResponse { error: message })).into_response()
+    }
+}
+
+impl From<JsonRejection> for AppError {
+    fn from(rejection: JsonRejection) -> Self {
+        AppError::BadRequest(rejection.body_text())
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,8 @@
 use axum::{
+    Json,
     extract::rejection::JsonRejection,
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
 };
 use serde::Serialize;
 
@@ -26,16 +26,15 @@ pub enum AppError {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
+        // NOTE: 500 errors are logged at the call site (handlers) with full context.
+        // into_response only builds the HTTP response — no duplicate logging here.
         let (status, message) = match self {
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
             AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
-            AppError::Internal(detail) => {
-                tracing::error!(error = %detail, "Internal server error");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "internal server error".to_string(),
-                )
-            }
+            AppError::Internal(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal server error".to_string(),
+            ),
         };
         (status, Json(ErrorResponse { error: message })).into_response()
     }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,26 +1,28 @@
 use askama::Template;
 use axum::{
     Form, Json,
-    extract::{Path, State},
+    extract::{Path, State, rejection::JsonRejection},
     http::StatusCode,
     response::Html,
 };
 use sqlx::SqlitePool;
 use std::sync::Arc;
 
+use crate::errors::AppError;
 use crate::models::{CreateTodo, CreateTodoForm, Todo, UpdateTodo};
 
 pub type AppState = Arc<SqlitePool>;
 
-pub async fn list_todos(State(pool): State<AppState>) -> Result<Json<Vec<Todo>>, StatusCode> {
-    let todos = fetch_todos(&pool).await?;
+pub async fn list_todos(State(pool): State<AppState>) -> Result<Json<Vec<Todo>>, AppError> {
+    let todos = fetch_all_todos(&pool).await?;
     Ok(Json(todos))
 }
 
 pub async fn create_todo(
     State(pool): State<AppState>,
-    Json(input): Json<CreateTodo>,
-) -> Result<(StatusCode, Json<Todo>), StatusCode> {
+    body: Result<Json<CreateTodo>, JsonRejection>,
+) -> Result<(StatusCode, Json<Todo>), AppError> {
+    let Json(input) = body?;
     let content = input.content.unwrap_or_default();
     let todo = sqlx::query_as::<_, Todo>(
         "INSERT INTO todos (title, content, completed) VALUES (?, ?, FALSE) RETURNING id, title, content, completed, created_at, updated_at",
@@ -31,7 +33,7 @@ pub async fn create_todo(
     .await
     .map_err(|e| {
         tracing::error!(error = %e, "Failed to create todo");
-        StatusCode::INTERNAL_SERVER_ERROR
+        AppError::Internal(e.to_string())
     })?;
     Ok((StatusCode::CREATED, Json(todo)))
 }
@@ -39,8 +41,9 @@ pub async fn create_todo(
 pub async fn update_todo(
     State(pool): State<AppState>,
     Path(id): Path<i64>,
-    Json(input): Json<UpdateTodo>,
-) -> Result<Json<Todo>, StatusCode> {
+    body: Result<Json<UpdateTodo>, JsonRejection>,
+) -> Result<Json<Todo>, AppError> {
+    let Json(input) = body?;
     let existing = sqlx::query_as::<_, Todo>(
         "SELECT id, title, content, completed, created_at, updated_at FROM todos WHERE id = ?",
     )
@@ -49,9 +52,9 @@ pub async fn update_todo(
     .await
     .map_err(|e| {
         tracing::error!(error = %e, id, "Failed to fetch todo for update");
-        StatusCode::INTERNAL_SERVER_ERROR
+        AppError::Internal(e.to_string())
     })?
-    .ok_or(StatusCode::NOT_FOUND)?;
+    .ok_or_else(|| AppError::NotFound("not found".to_string()))?;
 
     let title = input.title.unwrap_or(existing.title);
     let content = input.content.unwrap_or(existing.content);
@@ -68,7 +71,7 @@ pub async fn update_todo(
     .await
     .map_err(|e| {
         tracing::error!(error = %e, id, "Failed to update todo");
-        StatusCode::INTERNAL_SERVER_ERROR
+        AppError::Internal(e.to_string())
     })?;
     Ok(Json(todo))
 }
@@ -76,18 +79,18 @@ pub async fn update_todo(
 pub async fn delete_todo(
     State(pool): State<AppState>,
     Path(id): Path<i64>,
-) -> Result<StatusCode, StatusCode> {
+) -> Result<StatusCode, AppError> {
     let result = sqlx::query("DELETE FROM todos WHERE id = ?")
         .bind(id)
         .execute(pool.as_ref())
         .await
         .map_err(|e| {
             tracing::error!(error = %e, id, "Failed to delete todo");
-            StatusCode::INTERNAL_SERVER_ERROR
+            AppError::Internal(e.to_string())
         })?;
 
     if result.rows_affected() == 0 {
-        return Err(StatusCode::NOT_FOUND);
+        return Err(AppError::NotFound("not found".to_string()));
     }
     Ok(StatusCode::NO_CONTENT)
 }
@@ -112,7 +115,7 @@ struct TodoItemTemplate {
     todo: Todo,
 }
 
-async fn fetch_todos(pool: &SqlitePool) -> Result<Vec<Todo>, StatusCode> {
+async fn fetch_all_todos(pool: &SqlitePool) -> Result<Vec<Todo>, AppError> {
     sqlx::query_as::<_, Todo>(
         "SELECT id, title, content, completed, created_at, updated_at FROM todos ORDER BY id",
     )
@@ -120,43 +123,43 @@ async fn fetch_todos(pool: &SqlitePool) -> Result<Vec<Todo>, StatusCode> {
     .await
     .map_err(|e| {
         tracing::error!(error = %e, "Failed to fetch todos");
-        StatusCode::INTERNAL_SERVER_ERROR
+        AppError::Internal(e.to_string())
     })
 }
 
-fn render_html(template: &impl Template) -> Result<Html<String>, StatusCode> {
+fn render_html(template: &impl Template) -> Result<Html<String>, AppError> {
     Ok(Html(template.render().map_err(|e| {
         tracing::error!(error = %e, "Failed to render template");
-        StatusCode::INTERNAL_SERVER_ERROR
+        AppError::Internal(e.to_string())
     })?))
 }
 
-pub async fn index_page(State(pool): State<AppState>) -> Result<Html<String>, StatusCode> {
-    let todos = fetch_todos(pool.as_ref()).await?;
+pub async fn index_page(State(pool): State<AppState>) -> Result<Html<String>, AppError> {
+    let todos = fetch_all_todos(pool.as_ref()).await?;
     render_html(&IndexTemplate { todos })
 }
 
 pub async fn create_todo_html(
     State(pool): State<AppState>,
     Form(input): Form<CreateTodoForm>,
-) -> Result<Html<String>, StatusCode> {
+) -> Result<Html<String>, AppError> {
     sqlx::query("INSERT INTO todos (title, content, completed) VALUES (?, '', FALSE)")
         .bind(&input.title)
         .execute(pool.as_ref())
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to create todo (HTML)");
-            StatusCode::INTERNAL_SERVER_ERROR
+            AppError::Internal(e.to_string())
         })?;
 
-    let todos = fetch_todos(pool.as_ref()).await?;
+    let todos = fetch_all_todos(pool.as_ref()).await?;
     render_html(&TodoListTemplate { todos })
 }
 
 pub async fn toggle_todo_html(
     State(pool): State<AppState>,
     Path(id): Path<i64>,
-) -> Result<Html<String>, StatusCode> {
+) -> Result<Html<String>, AppError> {
     let todo = sqlx::query_as::<_, Todo>(
         "UPDATE todos SET completed = NOT completed, updated_at = CURRENT_TIMESTAMP WHERE id = ? RETURNING id, title, content, completed, created_at, updated_at",
     )
@@ -165,9 +168,9 @@ pub async fn toggle_todo_html(
     .await
     .map_err(|e| {
         tracing::error!(error = %e, id, "Failed to toggle todo");
-        StatusCode::INTERNAL_SERVER_ERROR
+        AppError::Internal(e.to_string())
     })?
-    .ok_or(StatusCode::NOT_FOUND)?;
+    .ok_or_else(|| AppError::NotFound("not found".to_string()))?;
 
     render_html(&TodoItemTemplate { todo })
 }
@@ -175,18 +178,18 @@ pub async fn toggle_todo_html(
 pub async fn delete_todo_html(
     State(pool): State<AppState>,
     Path(id): Path<i64>,
-) -> Result<Html<String>, StatusCode> {
+) -> Result<Html<String>, AppError> {
     let result = sqlx::query("DELETE FROM todos WHERE id = ?")
         .bind(id)
         .execute(pool.as_ref())
         .await
         .map_err(|e| {
             tracing::error!(error = %e, id, "Failed to delete todo (HTML)");
-            StatusCode::INTERNAL_SERVER_ERROR
+            AppError::Internal(e.to_string())
         })?;
 
     if result.rows_affected() == 0 {
-        return Err(StatusCode::NOT_FOUND);
+        return Err(AppError::NotFound("not found".to_string()));
     }
     Ok(Html(String::new()))
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -13,6 +13,21 @@ use crate::models::{CreateTodo, CreateTodoForm, Todo, UpdateTodo};
 
 pub type AppState = Arc<SqlitePool>;
 
+pub async fn health_check(
+    State(pool): State<AppState>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    match sqlx::query("SELECT 1").execute(pool.as_ref()).await {
+        Ok(_) => Ok(Json(serde_json::json!({"status": "ok"}))),
+        Err(e) => {
+            tracing::error!(error = %e, "Health check failed");
+            Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"status": "unhealthy", "error": e.to_string()})),
+            ))
+        }
+    }
+}
+
 pub async fn list_todos(State(pool): State<AppState>) -> Result<Json<Vec<Todo>>, AppError> {
     let todos = fetch_all_todos(&pool).await?;
     Ok(Json(todos))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod errors;
 pub mod handlers;
 pub mod models;
 
+pub use errors::{AppError, ErrorResponse};
 pub use handlers::AppState;
 pub use models::{CreateTodo, CreateTodoForm, Todo, UpdateTodo};
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -9,6 +9,12 @@ use tracing_subscriber::layer::SubscriberExt;
 
 use test_cekernel::{Todo, app, setup_db};
 
+/// Helper to parse an error response body as `{ "error": "..." }`.
+async fn body_error(response: axum::response::Response) -> String {
+    let body: serde_json::Value = body_json(response).await;
+    body["error"].as_str().unwrap().to_string()
+}
+
 async fn test_app() -> Router {
     let pool = SqlitePool::connect("sqlite::memory:")
         .await
@@ -513,6 +519,112 @@ async fn test_delete_todo_html() {
         todos.is_empty(),
         "Todo should be deleted after HTML delete endpoint"
     );
+}
+
+// ---- Structured Error Response Tests ----
+
+#[tokio::test]
+async fn test_create_invalid_json_returns_400_json() {
+    let app = test_app().await;
+    let res = app
+        .oneshot(json_request(
+            Method::POST,
+            "/todos",
+            Some(r#"{"not_a_field": 123}"#),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    let error_msg = body_error(res).await;
+    assert!(!error_msg.is_empty(), "Error message should not be empty");
+}
+
+#[tokio::test]
+async fn test_create_malformed_json_returns_400_json() {
+    let app = test_app().await;
+    let res = app
+        .oneshot(json_request(Method::POST, "/todos", Some(r#"{invalid"#)))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    let error_msg = body_error(res).await;
+    assert!(!error_msg.is_empty(), "Error message should not be empty");
+}
+
+#[tokio::test]
+async fn test_update_nonexistent_returns_404_json() {
+    let app = test_app().await;
+    let res = app
+        .oneshot(json_request(
+            Method::PATCH,
+            "/todos/999",
+            Some(r#"{"title":"Nope"}"#),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    let error_msg = body_error(res).await;
+    assert_eq!(error_msg, "not found");
+}
+
+#[tokio::test]
+async fn test_delete_nonexistent_returns_404_json() {
+    let app = test_app().await;
+    let res = app
+        .oneshot(json_request(Method::DELETE, "/todos/999", None))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    let error_msg = body_error(res).await;
+    assert_eq!(error_msg, "not found");
+}
+
+#[tokio::test]
+async fn test_db_error_returns_500_json() {
+    let pool = SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("Failed to connect");
+    setup_db(&pool).await;
+    let router = app(pool.clone());
+    pool.close().await;
+
+    let res = router
+        .oneshot(json_request(Method::GET, "/todos", None))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let error_msg = body_error(res).await;
+    assert_eq!(error_msg, "internal server error");
+}
+
+#[tokio::test]
+async fn test_update_invalid_json_returns_400_json() {
+    let app = test_app().await;
+
+    // Create a todo first
+    let res = app
+        .clone()
+        .oneshot(json_request(
+            Method::POST,
+            "/todos",
+            Some(r#"{"title":"Test"}"#),
+        ))
+        .await
+        .unwrap();
+    let todo: Todo = body_json(res).await;
+
+    // Send invalid JSON to update
+    let res = app
+        .oneshot(json_request(
+            Method::PATCH,
+            &format!("/todos/{}", todo.id),
+            Some(r#"{bad json"#),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    let error_msg = body_error(res).await;
+    assert!(!error_msg.is_empty(), "Error message should not be empty");
 }
 
 // ---- Tracing Tests ----


### PR DESCRIPTION
closes #110

## Summary
- `AppError` enum (`NotFound`/`BadRequest`/`Internal`) を導入し、全ハンドラのエラーを `{ "error": "message" }` 形式の JSON レスポンスに統一
- `JsonRejection` を捕捉して不正リクエストボディに 400 + JSON を返却
- 500 系エラーはハンドラで `tracing::error!` により詳細をログ記録、クライアントには `"internal server error"` のみ返却
- エラーケースのテスト 6 件追加（400/404/500 の JSON レスポンス検証）

## Test Plan
- [x] `make ci` 全パス（fmt --check, clippy, test, build --release）
- [x] 不正 JSON → 400 + `{ "error": "..." }`
- [x] 存在しない ID → 404 + `{ "error": "not found" }`
- [x] DB エラー → 500 + `{ "error": "internal server error" }` + tracing ログ
- [x] 既存テスト 19 件すべてパス（計 25 件）