### PR TITLE
docs: README.md / CLAUDE.md をコードの現状に同期する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-cekernelの実証テスト用リポジトリ。Rust + Axum によるシンプルなTODOリスト REST API。
+cekernelの実証テスト用リポジトリ。Rust + Axum による HTMX フロントエンド付き TODO Web アプリ。
 
 ## Development Environment
 
@@ -51,26 +51,42 @@ make up → TDD サイクル (RED → GREEN → REFACTOR) → make ci → PR作�
 
 ## Architecture
 
-- **Framework**: Axum 0.7（軽量Web）+ SQLite（sqlx async）
-- **エントリポイント**: `src/main.rs` — DB接続・サーバー起動（`PORT` 環境変数でポート指定可）
+- **Framework**: Axum 0.8（軽量Web）+ SQLite（sqlx async）+ Askama（テンプレート）
+- **エントリポイント**: `src/main.rs` — DB接続・サーバー起動・tracing初期化（`PORT` 環境変数でポート指定可）
 - **ルーター・DB初期化**: `src/lib.rs` — `app()`, `setup_db()`, re-exports
-- **モデル**: `src/models.rs` — `Todo`, `CreateTodo`, `UpdateTodo`
-- **ハンドラ**: `src/handlers.rs` — CRUD ハンドラ
+- **モデル**: `src/models.rs` — `Todo`, `CreateTodo`, `UpdateTodo`, `CreateTodoForm`
+- **ハンドラ**: `src/handlers.rs` — REST API + HTMX ハンドラ
+- **エラー**: `src/errors.rs` — `AppError`（NotFound/BadRequest/Internal）, `ErrorResponse`
+- **テンプレート**: `templates/` — Askama テンプレート（`index.html`, `todo_item.html`, `todo_list.html`）
 - **DB**: SQLite ファイル (`todos.db`)。コンテナ内でのみ存在し、gitignore済み。マイグレーションは `setup_db()` でアプリ起動時に実行
-- **テスト**: `tests/api.rs` — インテグレーションテスト。`sqlite::memory:` を使うためDBファイル不要
+- **トレーシング**: `tracing` + `tower-http` TraceLayer でリクエストログを出力
+- **テスト**: `tests/api.rs` — インテグレーションテスト（REST API・HTMLレスポンス・エラー応答・tracing出力検証）。`sqlite::memory:` を使うためDBファイル不要
+- **CI**: GitHub Actions（`ci.yml`）— path-filtering（`changes` ジョブ）→ fmt → clippy → test → build → `cargo-audit`（`gate` ジョブで集約）
 
 ## API Endpoints
+
+### HTML/HTMX
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | / | TODO 一覧ページ（HTMX フロントエンド） |
+| POST | / | TODO 作成（フォーム送信、HTMX） |
+| POST | /todos/{id}/toggle | 完了状態トグル（HTMX） |
+| POST | /todos/{id}/delete | 削除（HTMX） |
+
+### REST API
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | /health | ヘルスチェック (`{"status":"ok"}` or `503 {"status":"unhealthy","error":"..."}`) |
 | GET | /todos | 一覧取得 |
-| POST | /todos | 作成 (`{"title": "..."}`) |
-| PATCH | /todos/:id | 更新 (`{"title": "...", "completed": true}`) |
-| DELETE | /todos/:id | 削除 |
+| POST | /todos | 作成 (`{"title": "...", "content": "..."}`) |
+| PATCH | /todos/{id} | 更新 (`{"title": "...", "content": "...", "completed": true}`) |
+| DELETE | /todos/{id} | 削除 |
 
 ## Conventions
 
 - TDDアプローチ: テストを `tests/api.rs` に追加してから実装
 - 状態管理は `Arc<SqlitePool>` を Axum の `State` extractor で共有
 - テストは `tower::ServiceExt::oneshot` でルーターに直接リクエストを送る（HTTPサーバー不要）
+- 依存: `askama`（テンプレート）, `tracing` / `tracing-subscriber`（構造化ログ）, `tower-http`（TraceLayer, ServeDir）

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # test-cekernel
 
-[cekernel](https://github.com/clonable-eden/cekernel) の実証テスト用リポジトリ。Rust + Axum によるシンプルな TODO リスト REST API。
+[cekernel](https://github.com/clonable-eden/cekernel) の実証テスト用リポジトリ。Rust + Axum による HTMX フロントエンド付き TODO Web アプリ。
 
 ## Setup
 
@@ -18,12 +18,24 @@ make run     # サーバー起動 (http://localhost:3000)
 
 ## API
 
+### HTML/HTMX エンドポイント
+
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | / | TODO 一覧ページ（HTMX フロントエンド） |
+| POST | / | TODO 作成（フォーム送信、HTMX） |
+| POST | /todos/{id}/toggle | 完了状態トグル（HTMX） |
+| POST | /todos/{id}/delete | 削除（HTMX） |
+
+### REST API エンドポイント
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /health | ヘルスチェック (`{"status":"ok"}` or `503 {"status":"unhealthy","error":"..."}`) |
 | GET | /todos | 一覧取得 |
-| POST | /todos | 作成 (`{"title": "..."}`) |
-| PATCH | /todos/:id | 更新 (`{"title": "...", "completed": true}`) |
-| DELETE | /todos/:id | 削除 |
+| POST | /todos | 作成 (`{"title": "...", "content": "..."}`) |
+| PATCH | /todos/{id} | 更新 (`{"title": "...", "content": "...", "completed": true}`) |
+| DELETE | /todos/{id} | 削除 |
 
 ## Development
 
@@ -38,12 +50,20 @@ TDD アプローチで開発する。
 
 ```
 src/
-  main.rs        — エントリポイント（DB接続・サーバー起動）
+  main.rs        — エントリポイント（DB接続・サーバー起動・tracing初期化）
   lib.rs         — ルーター・DB初期化・re-exports
-  models.rs      — データモデル (Todo, CreateTodo, UpdateTodo)
-  handlers.rs    — CRUD ハンドラ
+  models.rs      — データモデル (Todo, CreateTodo, UpdateTodo, CreateTodoForm)
+  handlers.rs    — CRUD + HTMX ハンドラ
+  errors.rs      — エラー型 (AppError, ErrorResponse)
+templates/
+  index.html     — メインページテンプレート (Askama)
+  todo_item.html — TODO アイテム部分テンプレート
+  todo_list.html — TODO リスト部分テンプレート
 tests/
-  api.rs         — インテグレーションテスト
+  api.rs         — インテグレーションテスト（REST API・HTML・エラー応答・tracing）
+dev.mk           — 開発用 Makefile インクルード
+renovate.json    — Renovate 設定（依存自動更新）
+rust-toolchain.toml — Rust ツールチェーン指定
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- README.md / CLAUDE.md をプロジェクトの現状（HTMX フロントエンド、Axum 0.8、errors.rs、templates/ 等）に同期
- HTML/HTMX エンドポイント 4 つをドキュメントに追加
- パスパラメータ形式を `:id` → `{id}` に統一（Axum 0.8 形式）
- Architecture セクションに `errors.rs`, `templates/`, tracing, CI 構成を追加

## Test plan

- [x] ドキュメントの記載内容が `src/lib.rs` のルート定義と一致していることを確認
- [x] `Cargo.toml` の依存バージョンとドキュメントの記載が一致していることを確認

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)